### PR TITLE
docs: fix logo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # LambdaTest Maven Tunnel
 [![Maven Health Check](https://github.com/LambdaTest/lambdatest-maven-tunnel/actions/workflows/healthCheck.yml/badge.svg)](https://github.com/LambdaTest/lambdatest-maven-tunnel/actions/workflows/healthCheck.yml)
-![LambdaTest Logo](https://www.lambdatest.com/static/images/logo.svg)
+![LambdaTest Logo](https://www.lambdatest.com/resources/images/logos/logo.svg)
 
 ---
 


### PR DESCRIPTION
The LambdaTest logo link was broken.This PR fixes that.