### PR TITLE
fix: update README branding and remove non-template links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# Run TestMu AI Maven Tunnel on TestMu AI (Formerly LambdaTest)
+# Run TestMu AI Maven Tunnel on TestMu AI (Formerly LambdaTest)
 
 <p align="center">
   <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
@@ -17,9 +17,9 @@ With TestMu AI (Formerly LambdaTest), you can run tunnel-based local tests acros
 
 ### Prerequisites
 
-- [Java 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) or later (supports Java 17.0, 20.0, etc.)
-- [Maven](https://maven.apache.org/install.html) installed
-- A TestMu AI (Formerly LambdaTest) account — [sign up here](https://www.testmuai.com/register/)
+- Java 8 or later (supports Java 17.0, 20.0, etc.)
+- Maven installed
+- A TestMu AI (Formerly LambdaTest) account — sign up here
 
 ### Setup
 
@@ -87,7 +87,7 @@ tunnelArgs.put("dir", "give/lambda/directory/path");
 tunnelArgs.put("logFile", "give/tunnel/log/directory/path");
 ```
 
-For a full list of tunnel parameters, refer to the [TestMu AI Tunnel documentation](https://www.testmuai.com/support/docs/).
+For a full list of tunnel parameters, refer to the TestMu AI Tunnel documentation.
 
 ### Local testing with TestMu AI Tunnel
 


### PR DESCRIPTION
- Replace standalone LambdaTest with TestMu AI (Formerly LambdaTest) in body text\n- Remove non-template links from Prerequisites/Setup/Run tests sections