### PR TITLE
Maven Tunnel | Fix duplicate --basic-auth flag to support multiple Basic Auth URLs

### DIFF
--- a/src/main/java/com/lambdatest/tunnel/Tunnel.java
+++ b/src/main/java/com/lambdatest/tunnel/Tunnel.java
@@ -29,7 +29,7 @@ public class Tunnel {
     private static final List<String> IGNORE_KEYS = Arrays.asList("user", "key", "infoAPIPort", "binarypath",
             "load-balanced", "mitm", "pacfile", "mTLSHosts", "clientKey",
             "clientCert", "allowHosts", "verbose", "serverDomain", "usePrivateIp", "retry-proxy-error",
-            "retry-proxy-error-count", "ntlm", "ntlmPassword", "ntlmUsername", "maxSSHConnections");
+            "retry-proxy-error-count", "ntlm", "ntlmPassword", "ntlmUsername", "maxSSHConnections", "basicAuth");
 
     private boolean tunnelFlag = false;
     private final int MAX_TUNNEL_STARTUP_RETRY_COUNT = 20;


### PR DESCRIPTION
### Problem
The Maven tunnel client can only pass a single `basicAuth` URL to the tunnel binary. Passing multiple URLs makes the tunnel fail to start.

Root cause: `basicAuth` is present in the `parameters` map (`"basicAuth" -> "--basic-auth"`) but is **not** in `IGNORE_KEYS`. Both `passParametersToTunnel` and `passParametersToTunnelV2` first emit `--basic-auth <value>` in a dedicated block, then the generic parameter loop emits it **again**. The duplicated flag garbles the value list that the tunnel binary parses.

The binary's `--basic-auth` is a `StringSlice` flag, which natively splits a comma-separated value (`--basic-auth a,b` → `["a","b"]`). The duplicate flag was the only thing preventing multiple Basic Auth URLs from working.

### Fix
Add `basicAuth` to `IGNORE_KEYS` so the dedicated block is the sole owner of the flag. With the duplicate gone, a comma-separated `basicAuth` value is split by the binary, enabling multiple Basic Auth URLs.

```java
options.put("basicAuth", "https://user:pass@a.com,https://user:pass@b.com");
```

### Testing
Verified locally that Basic Auth is handled correctly for multiple URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)